### PR TITLE
Add basic l10n, request state handling widgets, and some minor other setup tasks

### DIFF
--- a/fireapp/l10n.yaml
+++ b/fireapp/l10n.yaml
@@ -1,0 +1,3 @@
+arb-dir: lib/l10n
+template-arb-file: app_en.arb
+output-localization-file: app_localizations.dart

--- a/fireapp/lib/base/pretty_exception.dart
+++ b/fireapp/lib/base/pretty_exception.dart
@@ -1,0 +1,6 @@
+
+abstract class PrettyException {
+
+  String? get message;
+
+}

--- a/fireapp/lib/base/spaced_by.dart
+++ b/fireapp/lib/base/spaced_by.dart
@@ -1,0 +1,17 @@
+
+import 'package:flutter/cupertino.dart';
+
+extension SpacedBy on List<Widget> {
+
+  List<Widget> spacedBy(double space) {
+    var output = <Widget>[];
+    for (Widget w in this) {
+      output
+        ..add(w)
+        ..add(SizedBox(width: space, height: space,));
+    }
+    output.removeLast();
+    return output;
+  }
+
+}

--- a/fireapp/lib/base/widget.dart
+++ b/fireapp/lib/base/widget.dart
@@ -1,10 +1,9 @@
 
 import 'package:fireapp/base/disposable.dart';
+import 'package:fireapp/presentation/fireapp_view_model.dart';
 import 'package:flutter/cupertino.dart';
 
-abstract class FireAppState<T extends StatefulWidget> extends State<T> {}
-
-abstract class ViewModelHolder<T> {
+abstract class ViewModelHolder<T extends FireAppViewModel> {
 
   late T viewModel;
 

--- a/fireapp/lib/data/client/api/api_di.dart
+++ b/fireapp/lib/data/client/api/api_di.dart
@@ -1,5 +1,6 @@
 
 import 'package:fireapp/data/client/api/rest_client.dart';
+import 'package:fireapp/data/client/api/token_interceptor.dart';
 import 'package:injectable/injectable.dart';
 import 'package:dio/dio.dart';
 
@@ -7,7 +8,10 @@ import 'package:dio/dio.dart';
 abstract class APIDependencyInjection {
 
   @singleton
-  Dio get dio => Dio();
+  Dio createDio(TokenInterceptor tokenInterceptor) {
+    return Dio()
+      ..interceptors.add(tokenInterceptor);
+  }
 
   @singleton
   RestClient createRestClient(Dio dio) {

--- a/fireapp/lib/data/client/api/token_interceptor.dart
+++ b/fireapp/lib/data/client/api/token_interceptor.dart
@@ -1,0 +1,22 @@
+import 'package:fireapp/data/persistence/authentication_persistence.dart';
+import 'package:injectable/injectable.dart';
+import 'package:dio/dio.dart';
+
+@injectable
+class TokenInterceptor extends InterceptorsWrapper {
+
+  static const authorizationHeader = "Authorization";
+
+  final AuthenticationPersistence _authenticationPersistence;
+  TokenInterceptor(this._authenticationPersistence);
+
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    var token = _authenticationPersistence.token;
+    if (token == null) return handler.next(options);
+
+    options.headers[authorizationHeader] = "Bearer ${_authenticationPersistence.token}";
+    handler.next(options);
+  }
+
+}

--- a/fireapp/lib/data/persistence/authentication_persistence.dart
+++ b/fireapp/lib/data/persistence/authentication_persistence.dart
@@ -5,6 +5,7 @@ import 'package:injectable/injectable.dart';
 class AuthenticationPersistence {
 
   TokenResponse? _cached;
+  String? get token => _cached?.accessToken;
 
   Future<void> set(TokenResponse auth) async {
     _cached = auth;

--- a/fireapp/lib/domain/request_state.dart
+++ b/fireapp/lib/domain/request_state.dart
@@ -16,7 +16,7 @@ abstract class RequestState<T> {
   factory RequestState.success(T result) = SuccessRequestState;
 
   /// Factory constructor that creates an `ExceptionRequestState` with a given [exception].
-  factory RequestState.exception(Object exception) = ExceptionRequestState;
+  factory RequestState.exception(Object? exception) = ExceptionRequestState;
 
 }
 
@@ -45,7 +45,7 @@ class SuccessRequestState<T> extends RequestState<T> {
 class ExceptionRequestState<T> extends RequestState<T> {
 
   /// The exception that occurred during the request.
-  final Object exception;
+  final Object? exception;
 
   /// Creates an exception request state with the given [exception].
   ExceptionRequestState(this.exception): super._();

--- a/fireapp/lib/l10n/app_en.arb
+++ b/fireapp/lib/l10n/app_en.arb
@@ -1,0 +1,14 @@
+{
+  "helloWorld": "Hello World!",
+  "@helloWorld": {
+    "description": "The conventional newborn programmer greeting"
+  },
+  "errorTitle": "Something went wrong",
+  "@errorTitle": {
+    "description": "The generic title shown on an error widget"
+  },
+  "errorActionRetry": "Retry",
+  "@errorActionRetry": {
+    "description": "The title shown on a button that retries the failed operation"
+  }
+}

--- a/fireapp/lib/main.dart
+++ b/fireapp/lib/main.dart
@@ -10,6 +10,8 @@ import 'package:fireapp/pages/Authentication/register.dart';
 import 'package:fireapp/pages/Authentication/login.dart';
 import 'package:fireapp/pages/Authentication/reset_password/reset_email.dart';
 import 'package:fireapp/pages/settings/setting.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 // Main Function
 void main() {
@@ -30,6 +32,15 @@ class _MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       theme: fireappTheme(),
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        AppLocalizations.delegate,
+      ],
+      supportedLocales: const [
+        Locale('en'),
+      ],
       title: 'Flutter Demo',
       initialRoute: '/login',
       routes: {

--- a/fireapp/lib/presentation/fireapp_page.dart
+++ b/fireapp/lib/presentation/fireapp_page.dart
@@ -1,0 +1,15 @@
+
+import 'package:fireapp/base/widget.dart';
+import 'package:flutter/cupertino.dart';
+
+abstract class FireAppState<T extends StatefulWidget> extends State<T> {
+
+  @override
+  void dispose() {
+    super.dispose();
+    if (this is ViewModelHolder) {
+      (this as ViewModelHolder).viewModel.dispose();
+    }
+  }
+
+}

--- a/fireapp/lib/widgets/error_widget.dart
+++ b/fireapp/lib/widgets/error_widget.dart
@@ -1,0 +1,30 @@
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+typedef ErrorWidgetRetryCallback = Function();
+
+class ErrorPresentationWidget extends StatelessWidget {
+
+  final Object? exception;
+  final String? message;
+  final ErrorWidgetRetryCallback? retry;
+
+  const ErrorPresentationWidget({super.key, this.exception, this.message, this.retry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(AppLocalizations.of(context)?.errorTitle ?? "", style: Theme.of(context).textTheme.titleSmall,),
+        if (message != null || exception != null) Text(message ?? "$exception"),
+        if (retry != null) OutlinedButton(
+          onPressed: retry,
+          child: Text(AppLocalizations.of(context)?.errorActionRetry ?? "")
+        )
+      ],
+    );
+  }
+
+}

--- a/fireapp/lib/widgets/error_widget.dart
+++ b/fireapp/lib/widgets/error_widget.dart
@@ -1,5 +1,6 @@
 
-import 'package:flutter/cupertino.dart';
+import 'package:fireapp/base/pretty_exception.dart';
+import 'package:fireapp/base/spaced_by.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
@@ -15,16 +16,32 @@ class ErrorPresentationWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    var message = _message();
     return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        Text(AppLocalizations.of(context)?.errorTitle ?? "", style: Theme.of(context).textTheme.titleSmall,),
-        if (message != null || exception != null) Text(message ?? "$exception"),
-        if (retry != null) OutlinedButton(
-          onPressed: retry,
-          child: Text(AppLocalizations.of(context)?.errorActionRetry ?? "")
+        Text(AppLocalizations.of(context)?.errorTitle ?? "", style: Theme.of(context).textTheme.titleLarge,),
+        if (message != null) Text(message),
+        if (retry != null) SizedBox(
+          width: 200,
+          child: OutlinedButton(
+            onPressed: retry,
+            child: Text(AppLocalizations.of(context)?.errorActionRetry ?? "")
+          ),
         )
-      ],
+      ].spacedBy(16),
     );
+  }
+
+  String? _message() {
+    if (message != null) return message;
+    if (exception == null) return null;
+    if (exception is PrettyException && (exception as PrettyException).message != null) {
+      return (exception as PrettyException).message;
+    }
+
+    return "$exception";
   }
 
 }

--- a/fireapp/lib/widgets/request_state_widget.dart
+++ b/fireapp/lib/widgets/request_state_widget.dart
@@ -14,7 +14,33 @@ class RequestStateWidget<T> extends StatelessWidget {
   final ErrorWidgetRetryCallback? retry;
   final bool shouldExpand;
 
-  const RequestStateWidget({super.key, required this.state, this.retry, this.shouldExpand = true,  required this.child});
+  const RequestStateWidget({super.key, required this.state, this.retry, this.shouldExpand = true, required this.child});
+
+  static Widget stream<T>({
+    Key? key,
+    required Stream<RequestState<T>> state,
+    required ErrorWidgetRetryCallback retry,
+    bool shouldExpand = true,
+    required RequestStateWidgetBuilder<T> child
+  }) {
+    return StreamBuilder<RequestState<T>>(
+      builder: (_,d) {
+        var state = d.data;
+        if (state == null && d.hasError) {
+          state = RequestState.exception(d.error);
+        }
+        if (state == null) return Container();
+
+        return RequestStateWidget(
+            key: key,
+            state: state,
+            retry: retry,
+            shouldExpand: shouldExpand,
+            child: child
+        );
+      }
+    );
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/fireapp/lib/widgets/request_state_widget.dart
+++ b/fireapp/lib/widgets/request_state_widget.dart
@@ -1,0 +1,32 @@
+
+import 'package:fireapp/domain/request_state.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'error_widget.dart';
+
+typedef RequestStateWidgetBuilder<T> = Widget Function(BuildContext context, T result);
+
+class RequestStateWidget<T> extends StatelessWidget {
+
+  final RequestStateWidgetBuilder<T> child;
+  final RequestState<T> state;
+  final ErrorWidgetRetryCallback? retry;
+
+  const RequestStateWidget({super.key, required this.child, required this.state, this.retry});
+
+  @override
+  Widget build(BuildContext context) {
+    if (state is SuccessRequestState) {
+      return child(context, (state as SuccessRequestState).result);
+    }
+    if (state is ExceptionRequestState) {
+      return ErrorPresentationWidget(
+        exception: (state as ExceptionRequestState).exception,
+        retry: retry,
+      );
+    }
+    return const CircularProgressIndicator();
+  }
+
+}

--- a/fireapp/lib/widgets/request_state_widget.dart
+++ b/fireapp/lib/widgets/request_state_widget.dart
@@ -12,21 +12,37 @@ class RequestStateWidget<T> extends StatelessWidget {
   final RequestStateWidgetBuilder<T> child;
   final RequestState<T> state;
   final ErrorWidgetRetryCallback? retry;
+  final bool shouldExpand;
 
-  const RequestStateWidget({super.key, required this.child, required this.state, this.retry});
+  const RequestStateWidget({super.key, required this.state, this.retry, this.shouldExpand = true,  required this.child});
 
   @override
   Widget build(BuildContext context) {
     if (state is SuccessRequestState) {
-      return child(context, (state as SuccessRequestState).result);
+      return _wrapper(child(context, (state as SuccessRequestState).result));
     }
     if (state is ExceptionRequestState) {
-      return ErrorPresentationWidget(
+      return _wrapper(ErrorPresentationWidget(
         exception: (state as ExceptionRequestState).exception,
         retry: retry,
-      );
+      ));
     }
-    return const CircularProgressIndicator();
+    return _wrapper(const CircularProgressIndicator());
+  }
+  
+  Widget _wrapper(Widget content) {
+    if (shouldExpand) {
+      return SizedBox(
+        width: double.infinity,
+        height: double.infinity,
+        child: Align(
+          alignment: Alignment.center,
+          child: content,
+        ),
+      );
+    } else {
+      return content;
+    }
   }
 
 }

--- a/fireapp/pubspec.lock
+++ b/fireapp/pubspec.lock
@@ -186,13 +186,13 @@ packages:
     source: hosted
     version: "2.2.4"
   dio:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: dio
-      sha256: "3709d74615bba5e443eb141f6a7f4bcc4788f8fae6f743edadfb79c2a8e6287e"
+      sha256: "2644a9e0965a7aa3deb09cb8ce4081db4450c178f472818c8cd34216a3070d7b"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.1"
+    version: "5.0.2"
   dio_cookie_manager:
     dependency: "direct dev"
     description:
@@ -246,6 +246,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_material_color_picker:
     dependency: transitive
     description:
@@ -369,7 +374,7 @@ packages:
     source: hosted
     version: "2.1.4"
   intl:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: intl
       sha256: "910f85bce16fb5c6f614e117efa303e85a1731bb0081edf3604a2ae6e9a3cc91"
@@ -809,10 +814,10 @@ packages:
     dependency: "direct main"
     description:
       name: table_calendar
-      sha256: "382f9f27c4d83240e9e70315a6e85e2136d95b4ab120926ed30c2670a0f41be6"
+      sha256: "7f1270313c0cdb245b583ed8518982c01d4a7e95869b3c30abcbae3b642c45d0"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.8"
   term_glyph:
     dependency: transitive
     description:

--- a/fireapp/pubspec.yaml
+++ b/fireapp/pubspec.yaml
@@ -31,6 +31,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
 
 
   # The following adds the Cupertino Icons font to your application.
@@ -48,6 +50,8 @@ dependencies:
   get_it: ^7.2.0
   injectable: ^2.1.0
   mockito: ^5.3.2
+  dio: ^5.0.2
+  intl: ^0.17.0
 
 dev_dependencies:
   flutter_test:
@@ -59,7 +63,6 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^2.0.0
-  dio: ^5.0.0
   cookie_jar: ^3.0.1
   dio_cookie_manager: ^2.0.0
   retrofit_generator: '>=5.0.0 <6.0.0'
@@ -77,6 +80,7 @@ flutter:
   # included with your application, so that you can use the icons in
   # the material Icons class.
   uses-material-design: true
+  generate: true
 
   # To add assets to your application, add an assets section, like this:
   # assets:


### PR DESCRIPTION
- The app now attaches the authentication token to network requests, assuming it has one
- The app will automatically dispose of ViewModels properly integrated with the framework
- Errors have a uniform widget. This is currently unstyled, but will be styled when the general styling changes are implemented