### PR TITLE
DRAFT: Dietary requirements page

### DIFF
--- a/fireapp/lib/base/list_extensions.dart
+++ b/fireapp/lib/base/list_extensions.dart
@@ -8,4 +8,11 @@ extension ListExtensions<T> on List<T> {
     return false;
   }
 
+  T? firstOrNull(bool Function(T) test) {
+    for (T e in this) {
+      if (test(e)) return e;
+    }
+    return null;
+  }
+
 }

--- a/fireapp/lib/base/list_extensions.dart
+++ b/fireapp/lib/base/list_extensions.dart
@@ -1,0 +1,11 @@
+
+extension ListExtensions<T> on List<T> {
+
+  bool has(bool Function(T) test) {
+    for (T e in this) {
+      if (test(e)) return true;
+    }
+    return false;
+  }
+
+}

--- a/fireapp/lib/domain/models/dietary_requirements.dart
+++ b/fireapp/lib/domain/models/dietary_requirements.dart
@@ -1,0 +1,29 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:flutter/foundation.dart';
+
+part 'dietary_requirements.freezed.dart';
+part 'dietary_requirements.g.dart';
+
+@freezed
+class DietaryRequirements with _$DietaryRequirements {
+
+  const factory DietaryRequirements({
+    required List<DietaryRestriction> restrictions,
+    required String? customRestrictions
+  }) = _DietaryRequirements;
+
+  factory DietaryRequirements.fromJson(Map<String, Object?> json) => _$DietaryRequirementsFromJson(json);
+
+}
+
+@freezed
+class DietaryRestriction with _$DietaryRestriction {
+
+  const factory DietaryRestriction({
+    required String key,
+    required String displayName
+  }) = _DietaryRestriction;
+
+  factory DietaryRestriction.fromJson(Map<String, Object?> json) => _$DietaryRestrictionFromJson(json);
+
+}

--- a/fireapp/lib/domain/repository/dietary_requirements_repository.dart
+++ b/fireapp/lib/domain/repository/dietary_requirements_repository.dart
@@ -1,0 +1,25 @@
+
+import 'package:fireapp/domain/models/dietary_requirements.dart';
+import 'package:injectable/injectable.dart';
+
+@injectable
+class DietaryRequirementsRepository {
+
+  final _options = [
+    const DietaryRestriction(key: "peanut", displayName: "Peanuts")
+  ];
+
+  Future<List<DietaryRestriction>> getOptions() async {
+    return _options;
+  }
+
+  Future<DietaryRequirements> getDietaryRequirements() async {
+    return DietaryRequirements(
+      restrictions: _options,
+      customRestrictions: null
+    );
+  }
+
+  Future<void> updateDietaryRequirements(DietaryRequirements requirements) async {}
+
+}

--- a/fireapp/lib/l10n/app_en.arb
+++ b/fireapp/lib/l10n/app_en.arb
@@ -10,5 +10,9 @@
   "errorActionRetry": "Retry",
   "@errorActionRetry": {
     "description": "The title shown on a button that retries the failed operation"
+  },
+  "dietaryRequirementsCustomTitle": "Other dietary requirements",
+  "@dietaryRequirementsCustomTitle": {
+    "description": "Shown above the custom dietary requirements text box"
   }
 }

--- a/fireapp/lib/main.dart
+++ b/fireapp/lib/main.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: prefer_const_constructors
 // EXTERNAL
 import 'package:fireapp/global/di.dart';
+import 'package:fireapp/presentation/dietary_requirements/dietary_requirements_page.dart';
 import 'package:flutter/material.dart';
 //INTERNAL
 import 'layout/wrapper.dart';
@@ -51,6 +52,7 @@ class _MyAppState extends State<MyApp> {
         '/register': (context) => const BasicWrapper(
             page: RegisterPage()), //See Authentication/register.dart
         '/reset_password': (context) => const BasicWrapper(page: ResetPage()),
+        '/dietary_requirements/update': (context) => const DietaryRequirementsPage()
       },
     );
   }

--- a/fireapp/lib/presentation/dietary_requirements/dietary_requirements_page.dart
+++ b/fireapp/lib/presentation/dietary_requirements/dietary_requirements_page.dart
@@ -1,0 +1,16 @@
+import 'package:fireapp/layout/wrapper.dart';
+import 'package:fireapp/presentation/dietary_requirements/dietary_requirements_widget.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class DietaryRequirementsPage extends StatelessWidget {
+  const DietaryRequirementsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const BasicWrapper(
+      page: DietaryRequirementsWidget()
+    )
+  }
+
+}

--- a/fireapp/lib/presentation/dietary_requirements/dietary_requirements_page.dart
+++ b/fireapp/lib/presentation/dietary_requirements/dietary_requirements_page.dart
@@ -10,7 +10,7 @@ class DietaryRequirementsPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return const BasicWrapper(
       page: DietaryRequirementsWidget()
-    )
+    );
   }
 
 }

--- a/fireapp/lib/presentation/dietary_requirements/dietary_requirements_presentation_model.dart
+++ b/fireapp/lib/presentation/dietary_requirements/dietary_requirements_presentation_model.dart
@@ -1,0 +1,26 @@
+import 'package:fireapp/domain/models/dietary_requirements.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:flutter/foundation.dart';
+
+part 'dietary_requirements_presentation_model.freezed.dart';
+
+@freezed
+class UserDietaryRequirements with _$UserDietaryRequirements {
+
+  const factory UserDietaryRequirements({
+    required List<UserDietaryRestriction> restrictions,
+    required String? customRestrictions
+  }) = _UserDietaryRequirements;
+
+}
+
+@freezed
+class UserDietaryRestriction with _$UserDietaryRestriction {
+
+  const factory UserDietaryRestriction({
+    required DietaryRestriction restriction,
+    required bool checked
+  }) = _UserDietaryRestriction;
+
+}
+

--- a/fireapp/lib/presentation/dietary_requirements/dietary_requirements_presentation_model.dart
+++ b/fireapp/lib/presentation/dietary_requirements/dietary_requirements_presentation_model.dart
@@ -8,8 +8,7 @@ part 'dietary_requirements_presentation_model.freezed.dart';
 class UserDietaryRequirements with _$UserDietaryRequirements {
 
   const factory UserDietaryRequirements({
-    required List<UserDietaryRestriction> restrictions,
-    required String? customRestrictions
+    required List<UserDietaryRestriction> restrictions
   }) = _UserDietaryRequirements;
 
 }

--- a/fireapp/lib/presentation/dietary_requirements/dietary_requirements_view_model.dart
+++ b/fireapp/lib/presentation/dietary_requirements/dietary_requirements_view_model.dart
@@ -6,6 +6,7 @@ import 'package:fireapp/domain/request_state.dart';
 import 'package:fireapp/global/di.dart';
 import 'package:fireapp/presentation/dietary_requirements/dietary_requirements_presentation_model.dart';
 import 'package:fireapp/presentation/fireapp_view_model.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:injectable/injectable.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -17,9 +18,8 @@ class DietaryRequirementsViewModel extends FireAppViewModel {
   final BehaviorSubject<RequestState<UserDietaryRequirements>> _requirements
     = BehaviorSubject.seeded(RequestState.initial());
   final BehaviorSubject<List<UserDietaryRestriction>> _changes = BehaviorSubject.seeded([]);
-  final BehaviorSubject<String?> _customRestrictions = BehaviorSubject.seeded(null);
 
-  Stream<String?> get customRestrictions => _customRestrictions.stream;
+  TextEditingController customRestrictions = TextEditingController();
   Stream<RequestState<UserDietaryRequirements>> get requirements
     => Rx.combineLatest2(_requirements.stream, _changes.stream,
       (RequestState<UserDietaryRequirements> sot, List<UserDietaryRestriction> c) {
@@ -49,7 +49,7 @@ class DietaryRequirementsViewModel extends FireAppViewModel {
           )
         ).toList();
 
-        _customRestrictions.add(userData.customRestrictions);
+        customRestrictions.text = userData.customRestrictions ?? "";
         _changes.add([]);
         _requirements.add(RequestState.success(
           UserDietaryRequirements(
@@ -73,7 +73,7 @@ class DietaryRequirementsViewModel extends FireAppViewModel {
   }
 
   void updateCustomRestriction(String? value) {
-    _customRestrictions.add(value);
+    customRestrictions.text = value ?? "";
   }
 
   void submit() {
@@ -85,7 +85,7 @@ class DietaryRequirementsViewModel extends FireAppViewModel {
     _dietaryRequirementsRepository.updateDietaryRequirements(
       DietaryRequirements(
         restrictions: changedRestrictions.where((e) => e.checked).map((e) => e.restriction).toList(),
-        customRestrictions: _customRestrictions.value
+        customRestrictions: customRestrictions.text
       )
     );
   }

--- a/fireapp/lib/presentation/dietary_requirements/dietary_requirements_view_model.dart
+++ b/fireapp/lib/presentation/dietary_requirements/dietary_requirements_view_model.dart
@@ -109,7 +109,6 @@ class DietaryRequirementsViewModel extends FireAppViewModel {
   Future<void> dispose() async {
     _requirements.close();
     _changes.close();
-    _customRestrictions.close();
   }
 
 }

--- a/fireapp/lib/presentation/dietary_requirements/dietary_requirements_view_model.dart
+++ b/fireapp/lib/presentation/dietary_requirements/dietary_requirements_view_model.dart
@@ -1,0 +1,56 @@
+
+import 'package:fireapp/base/list_extensions.dart';
+import 'package:fireapp/domain/models/dietary_requirements.dart';
+import 'package:fireapp/domain/repository/dietary_requirements_repository.dart';
+import 'package:fireapp/domain/request_state.dart';
+import 'package:fireapp/global/di.dart';
+import 'package:fireapp/presentation/dietary_requirements/dietary_requirements_presentation_model.dart';
+import 'package:fireapp/presentation/fireapp_view_model.dart';
+import 'package:injectable/injectable.dart';
+import 'package:rxdart/rxdart.dart';
+
+@injectable
+class DietaryRequirementsViewModel extends FireAppViewModel {
+
+  final DietaryRequirementsRepository _dietaryRequirementsRepository;
+
+  final BehaviorSubject<RequestState<UserDietaryRequirements>> _requirements
+    = BehaviorSubject.seeded(RequestState.initial());
+  Stream<RequestState<UserDietaryRequirements>> get requirements => _requirements.stream;
+
+  DietaryRequirementsViewModel(this._dietaryRequirementsRepository);
+
+  void load() {
+    _requirements.add(RequestState.loading());
+    () async {
+      try {
+        final options = await _dietaryRequirementsRepository.getOptions();
+        final userData = await _dietaryRequirementsRepository.getDietaryRequirements();
+
+        final userRestrictions = options.map((o) =>
+          UserDietaryRestriction(
+            restriction: o,
+            checked: userData.restrictions.contains(o)
+          )
+        ).toList();
+
+        _requirements.add(RequestState.success(
+          UserDietaryRequirements(
+            restrictions: userRestrictions,
+            customRestrictions: userData.customRestrictions
+          )
+        ));
+      } catch (e) {
+        logger.e(e);
+        _requirements.add(RequestState.exception(e));
+      }
+
+    }();
+  }
+
+  @override
+  Future<void> dispose() async {
+    _requirements.close();
+  }
+
+}

--- a/fireapp/lib/presentation/dietary_requirements/dietary_requirements_widget.dart
+++ b/fireapp/lib/presentation/dietary_requirements/dietary_requirements_widget.dart
@@ -1,0 +1,23 @@
+
+import 'package:fireapp/presentation/fireapp_page.dart';
+import 'package:flutter/cupertino.dart';
+
+class DietaryRequirementsWidget extends StatefulWidget {
+
+  const DietaryRequirementsWidget({super.key});
+
+  @override
+  State createState() => _DietaryRequirementsWidgetState();
+
+}
+
+class _DietaryRequirementsWidgetState extends FireAppState<DietaryRequirementsWidget> {
+
+
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+
+}

--- a/fireapp/lib/presentation/dietary_requirements/dietary_requirements_widget.dart
+++ b/fireapp/lib/presentation/dietary_requirements/dietary_requirements_widget.dart
@@ -1,10 +1,14 @@
 
+import 'package:fireapp/base/spaced_by.dart';
 import 'package:fireapp/base/widget.dart';
+import 'package:fireapp/presentation/dietary_requirements/dietary_requirements_presentation_model.dart';
 import 'package:fireapp/presentation/dietary_requirements/dietary_requirements_view_model.dart';
 import 'package:fireapp/presentation/fireapp_page.dart';
 import 'package:fireapp/widgets/request_state_widget.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 class DietaryRequirementsWidget extends StatefulWidget {
 
@@ -29,12 +33,46 @@ class _DietaryRequirementsWidgetState extends FireAppState<DietaryRequirementsWi
 
   @override
   Widget build(BuildContext context) {
-    return RequestStateWidget.stream(
+    return RequestStateWidget.stream<UserDietaryRequirements>(
       state: viewModel.requirements,
       retry: () { viewModel.load(); },
       child: (_, restrictions) {
-        return Container();
+        return Column(
+          children: [
+            Column(
+              children: restrictions.restrictions
+                  .map((e) => _restriction(e))
+                  .toList()
+                  .spacedBy(8),
+            ),
+            Column(
+              children: [
+                Text(
+                  AppLocalizations.of(context)?.dietaryRequirementsCustomTitle ?? "",
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                TextField(
+                  keyboardType: TextInputType.multiline,
+                  maxLines: null,
+                  controller: viewModel.customRestrictions,
+                )
+              ].spacedBy(8),
+            )
+          ].spacedBy(16),
+        );
       }
+    );
+  }
+
+  Widget _restriction(UserDietaryRestriction restriction) {
+    return Row(
+      children: [
+        Checkbox(
+          value: restriction.checked,
+          onChanged: (v) => viewModel.updateRequirement(restriction.restriction, !restriction.checked)
+        ),
+        Text(restriction.restriction.displayName)
+      ].spacedBy(8),
     );
   }
 

--- a/fireapp/lib/presentation/dietary_requirements/dietary_requirements_widget.dart
+++ b/fireapp/lib/presentation/dietary_requirements/dietary_requirements_widget.dart
@@ -1,6 +1,10 @@
 
+import 'package:fireapp/base/widget.dart';
+import 'package:fireapp/presentation/dietary_requirements/dietary_requirements_view_model.dart';
 import 'package:fireapp/presentation/fireapp_page.dart';
+import 'package:fireapp/widgets/request_state_widget.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:get_it/get_it.dart';
 
 class DietaryRequirementsWidget extends StatefulWidget {
 
@@ -11,13 +15,27 @@ class DietaryRequirementsWidget extends StatefulWidget {
 
 }
 
-class _DietaryRequirementsWidgetState extends FireAppState<DietaryRequirementsWidget> {
+class _DietaryRequirementsWidgetState extends FireAppState<DietaryRequirementsWidget>
+    implements ViewModelHolder<DietaryRequirementsViewModel> {
 
+  @override
+  DietaryRequirementsViewModel viewModel = GetIt.instance.get();
 
+  @override
+  void initState() {
+    super.initState();
+    viewModel.load();
+  }
 
   @override
   Widget build(BuildContext context) {
-    return Container();
+    return RequestStateWidget.stream(
+      state: viewModel.requirements,
+      retry: () { viewModel.load(); },
+      child: (_, restrictions) {
+        return Container();
+      }
+    );
   }
 
 }

--- a/fireapp/pubspec.yaml
+++ b/fireapp/pubspec.yaml
@@ -67,7 +67,7 @@ dev_dependencies:
   dio_cookie_manager: ^2.0.0
   retrofit_generator: '>=5.0.0 <6.0.0'
   build_runner: '>=2.3.0 <4.0.0'
-  json_serializable: any
+  json_serializable: '>4.8.0'
   injectable_generator: ^2.1.0
 
 # For information on the generic Dart part of this file, see the


### PR DESCRIPTION
Implements the dietary requirements page, although this is largely untested due to the API work is incomplete. Once it is complete, this task will be moved out of DRAFT and be later merged.

| Action | Expected, observable result after action | Pass |
|--------|-----------------------------|----|
| Tap dietary restriction checkbox | The checkbox value updates | ☑️ |
| Enter text into custom box | The text updates | ☑️ |
| Press submit | The server updates to reflect the changes | |