### PR TITLE
Fix dependency injection of reference data persistence

### DIFF
--- a/fireapp/lib/data/persistence/db/db.dart
+++ b/fireapp/lib/data/persistence/db/db.dart
@@ -23,12 +23,12 @@ abstract class DBDependencyInjection {
   }
 
   @singleton
-  ReferenceDataDbDao createReferenceDataDbDao(AppDatabase db) {
+  Future<ReferenceDataDbDao> createReferenceDataDbDao(AppDatabase db) async {
     return db.referenceDataDbDao;
   }
 
   @singleton
-  ReferenceDataDbMetadataDao createReferenceDataDbMetadataDao(AppDatabase db) {
+  Future<ReferenceDataDbMetadataDao> createReferenceDataDbMetadataDao(AppDatabase db) async {
     return db.referenceDataDbMetadataDao;
   }
 

--- a/fireapp/lib/data/persistence/reference_data_persistence.dart
+++ b/fireapp/lib/data/persistence/reference_data_persistence.dart
@@ -14,6 +14,7 @@ class ReferenceDataPersistence {
   late ReferenceDataDbMetadataDao _dataDbMetadataDao;
   late Future<void> isSetup;
 
+  // coverage:ignore-start
   // This should be done through DI (hence .di), but asynchronous constructors are wack
   @factoryMethod
   ReferenceDataPersistence() {
@@ -22,6 +23,8 @@ class ReferenceDataPersistence {
       _dataDbMetadataDao = await GetIt.instance.getAsync();
     }();
   }
+  // coverage:ignore-end
+
   ReferenceDataPersistence.di(this._dataDbDao, this._dataDbMetadataDao) {
     isSetup = Future.value(null);
   }

--- a/fireapp/lib/data/persistence/reference_data_persistence.dart
+++ b/fireapp/lib/data/persistence/reference_data_persistence.dart
@@ -1,6 +1,7 @@
 
 import 'package:fireapp/domain/models/reference/reference_data.dart';
 import 'package:fireapp/domain/models/reference/reference_data_db.dart';
+import 'package:get_it/get_it.dart';
 import 'package:injectable/injectable.dart';
 
 import 'db/reference_data_db_dao.dart';
@@ -9,17 +10,31 @@ import 'db/reference_data_db_metadata_dao.dart';
 @injectable
 class ReferenceDataPersistence {
 
-  final ReferenceDataDbDao _dataDbDao;
-  final ReferenceDataDbMetadataDao _dataDbMetadataDao;
-  ReferenceDataPersistence(this._dataDbDao, this._dataDbMetadataDao);
+  late ReferenceDataDbDao _dataDbDao;
+  late ReferenceDataDbMetadataDao _dataDbMetadataDao;
+  late Future<void> isSetup;
+
+  // This should be done through DI (hence .di), but asynchronous constructors are wack
+  @factoryMethod
+  ReferenceDataPersistence() {
+    isSetup = () async {
+      _dataDbDao = await GetIt.instance.getAsync();
+      _dataDbMetadataDao = await GetIt.instance.getAsync();
+    }();
+  }
+  ReferenceDataPersistence.di(this._dataDbDao, this._dataDbMetadataDao) {
+    isSetup = Future.value(null);
+  }
 
   Future<DateTime?> getLastUpdated(ReferenceDataType type) async {
+    await isSetup;
     var metadata = await _dataDbMetadataDao.getByType(type.name);
     if (metadata == null) return null;
     return DateTime.fromMillisecondsSinceEpoch(metadata.lastRefreshed);
   }
 
   Future<void> save(ReferenceDataType type, List<ReferenceDataDb> data) async {
+    await isSetup;
     _dataDbMetadataDao.insertReferenceData(ReferenceDataDbMetadata(
       type: type.name,
       lastRefreshed: DateTime.now().millisecondsSinceEpoch
@@ -28,6 +43,7 @@ class ReferenceDataPersistence {
   }
 
   Future<List<ReferenceDataDb>> getReferenceData(ReferenceDataType type) async {
+    await isSetup;
     return _dataDbDao.getByType(type.name);
   }
 

--- a/fireapp/lib/presentation/volunteer_information/volunteer_information.dart
+++ b/fireapp/lib/presentation/volunteer_information/volunteer_information.dart
@@ -26,7 +26,9 @@ class VolunteerInformationPage extends StatefulWidget {
   State createState() => _VolunteerInformationState();
 }
 
-class _VolunteerInformationState extends FireAppState<VolunteerInformationPage>{
+class _VolunteerInformationState
+    extends FireAppState<VolunteerInformationPage>
+    implements ViewModelHolder<VolunteerInformationViewModel> {
   String getAvailabilityMessage(BuildContext context, List<List<int>> availability) {
     if (availability.isEmpty) {
       return AppLocalizations.of(context)?.unavailable ?? 'Unavailable';

--- a/fireapp/test/data/persistence/reference_data_persistence_test.dart
+++ b/fireapp/test/data/persistence/reference_data_persistence_test.dart
@@ -21,7 +21,7 @@ void main() {
   setUp(() {
     dataDbDao = MockReferenceDataDbDao();
     dataDbMetadataDao = MockReferenceDataDbMetadataDao();
-    persistence = ReferenceDataPersistence(dataDbDao, dataDbMetadataDao);
+    persistence = ReferenceDataPersistence.di(dataDbDao, dataDbMetadataDao);
   });
 
   group('ReferenceDataPersistence', () {


### PR DESCRIPTION
## Describe your changes
Asynchronous factories are causing havoc. To get around this, the ReferenceDataPersistence class now constructs it's down dependencies, blocking calls to it until it is complete. To continue to allow unit testing, a new "di" constructor has been introduced. 

## Issue ticket number and link
