### PR TITLE
Add asset type model & data layer

### DIFF
--- a/fireapp/lib/data/client/api/rest_client.dart
+++ b/fireapp/lib/data/client/api/rest_client.dart
@@ -11,6 +11,7 @@ import 'package:retrofit/retrofit.dart';
 import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
 
+import '../../../domain/models/reference/asset_type.dart';
 import '../../../domain/models/role_request.dart';
 import '../../../domain/models/shift_request.dart';
 
@@ -34,6 +35,9 @@ abstract class RestClient {
 
   @GET("/v2/reference/roles")
   Future<List<VolunteerRole>> getRoles();
+
+  @GET("/reference/asset_types")
+  Future<List<AssetType>> getAssetTypes();
 
   @GET("/volunteer")
   Future<VolunteerInformationDto> getVolunteerInformation(

--- a/fireapp/lib/data/client/reference_data_client.dart
+++ b/fireapp/lib/data/client/reference_data_client.dart
@@ -4,6 +4,8 @@ import 'package:fireapp/domain/models/reference/volunteer_role.dart';
 import 'package:fireapp/domain/models/volunteer_listing.dart';
 import 'package:injectable/injectable.dart';
 
+import '../../domain/models/reference/asset_type.dart';
+
 @injectable
 class ReferenceDataClient {
 
@@ -16,6 +18,10 @@ class ReferenceDataClient {
 
   Future<List<VolunteerRole>> getRoles() {
     return restClient.getRoles();
+  }
+
+  Future<List<AssetType>> getAssetTypes() {
+    return restClient.getAssetTypes();
   }
 
 }

--- a/fireapp/lib/domain/models/reference/asset_type.dart
+++ b/fireapp/lib/domain/models/reference/asset_type.dart
@@ -1,0 +1,24 @@
+
+import 'package:fireapp/domain/models/reference/reference_data.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'asset_type.freezed.dart';
+part 'asset_type.g.dart';
+
+@freezed
+class AssetType
+    with _$AssetType
+    implements CodeableReferenceData {
+
+  @Implements<CodeableReferenceData>()
+  const factory AssetType({
+    required int id,
+    required String name,
+    required String code,
+    required DateTime updated,
+    required DateTime created
+  }) = _AssetType;
+
+  factory AssetType.fromJson(Map<String, Object?> json) => _$AssetTypeFromJson(json);
+
+}

--- a/fireapp/lib/domain/models/reference/reference_data.dart
+++ b/fireapp/lib/domain/models/reference/reference_data.dart
@@ -2,7 +2,7 @@
 import 'package:fireapp/domain/models/base/identifiable.dart';
 
 enum ReferenceDataType {
-  qualification, role
+  qualification, role, assetType
 }
 
 abstract class ReferenceData extends Identifiable<int> {

--- a/fireapp/lib/domain/repository/reference_data_repository.dart
+++ b/fireapp/lib/domain/repository/reference_data_repository.dart
@@ -1,4 +1,5 @@
 import 'package:fireapp/data/client/reference_data_client.dart';
+import 'package:fireapp/domain/models/reference/asset_type.dart';
 import 'package:fireapp/domain/models/reference/qualification.dart';
 import 'package:fireapp/domain/models/reference/reference_data.dart';
 import 'package:fireapp/domain/models/reference/reference_data_db.dart';
@@ -40,6 +41,20 @@ class ReferenceDataRepository {
             created: DateTime.fromMillisecondsSinceEpoch(e.created),
         ),
             () => _client.getRoles()
+    );
+  }
+
+  Future<List<AssetType>> getAssetType() async {
+    return _fetch<AssetType>(
+        ReferenceDataType.assetType,
+            (e) => AssetType(
+          id: e.id,
+          name: e.name,
+          code: e.code ?? "",
+          updated: DateTime.fromMillisecondsSinceEpoch(e.updated),
+          created: DateTime.fromMillisecondsSinceEpoch(e.created),
+        ),
+            () => _client.getAssetTypes()
     );
   }
 

--- a/fireapp/lib/domain/repository/reference_data_repository.dart
+++ b/fireapp/lib/domain/repository/reference_data_repository.dart
@@ -62,15 +62,15 @@ class ReferenceDataRepository {
       ReferenceDataType type,
       T Function(ReferenceDataDb) map,
       Future<List<T>> Function() get,
-      ) async {
-        var current = await _persistence.getLastUpdated(type);
-        if (
+  ) async {
+    var current = await _persistence.getLastUpdated(type);
+    if (
         current != null &&
-            current.millisecondsSinceEpoch + lifetime > DateTime.now().millisecondsSinceEpoch
-        ) {
-          return (await _persistence.getReferenceData(type)).map((e) => map(e)).toList();
-        }
-        var data = await get();
+        current.millisecondsSinceEpoch + lifetime > DateTime.now().millisecondsSinceEpoch
+    ) {
+      return (await _persistence.getReferenceData(type)).map((e) => map(e)).toList();
+    }
+    var data = await get();
 
     _persistence.save(type, data.map((e) {
       return ReferenceDataDb(


### PR DESCRIPTION
## Describe your changes
This commit adds functionality for retrieving asset types from the server. It includes changes to the REST client, reference data client, domain models, and repository. The new `AssetType` model is introduced along with its associated JSON serialization and deserialization logic. The `getAssetTypes` method is added to both the REST client and reference data client to fetch asset types from the server. Finally, the `getAssetType` method is implemented in the reference data repository to retrieve a list of asset types using the `_fetch` helper function.

## Issue ticket number and link
